### PR TITLE
fixed：多次点击播放会卡死的bug

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -42,6 +42,7 @@ const player = {
     player.ui.demo.scrollTop = player.ui.demo.scrollHeight
   },
   play: () => {
+    window.clearInterval(player.id)
     player.id = setInterval(player.run, player.time)
   },
   pause: () => {


### PR DESCRIPTION
重复点击播放，导致重复设置setInterval并覆盖id，原先的setInterval无法删除。